### PR TITLE
Use latest tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.7.0
+FROM vllm/vllm-openai:latest
 
 ARG model_id
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Artifacts to build and deploy a container with vLLM and granite, exposed via RES
 
 ##  vLLM container with IBM Granite
 
-The following command builds a vLLM container image which pulls Granite models from HuggingFace. It uses the official vLLM image as base.
+The following command builds a vLLM container image which pulls Granite models from HuggingFace. It uses the [official vLLM image](https://hub.docker.com/r/vllm/vllm-openai/tags) as base.  
+
+Please note: the `Dockerfile` uses the `latest` tag, which points to the most up-to-date tag available.  Internally we have tested with version `v0.7.0`.
 
 ```
 docker buildx build --tag vllm_with_model -f Dockerfile.model --build-arg model_id=ibm-granite/granite-3.1-8b-instruct .


### PR DESCRIPTION
There's a `latest` tag for the vLLM Docker image (https://hub.docker.com/r/vllm/vllm-openai/tags) which always points to the latest tag.  Could we use that one, so that our Dockerfile is always up-to-date?